### PR TITLE
add read_timeout configuration for HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Communicate with Nessus Scanner (version 6+) over REST/JSON interface
 ```ruby
 require 'nessus_rest'
 
-n = NessusREST::Client.new (
+n = NessusREST::Client.new(
 	url: 'https://localhost:8834',
 	username: 'user',
-	password: 'password')
+	password: 'password',
+	read_timeout: 30)
 qs = n.scan_quick_template('basic','name-of-scan','localhost')
 scanid = qs['scan']['id']
 n.scan_wait4finish(scanid)

--- a/lib/nessus_rest/http.rb
+++ b/lib/nessus_rest/http.rb
@@ -17,11 +17,8 @@ module NessusREST
       uri = URI.parse(options[:url])
       @connection = Net::HTTP.new(uri.host, uri.port)
       @connection.use_ssl = options[:ssl_use]
-      @connection.verify_mode = if options[:ssl_verify]
-                                  OpenSSL::SSL::VERIFY_PEER
-                                else
-                                  OpenSSL::SSL::VERIFY_NONE
-                                end
+      @connection.verify_mode = options[:ssl_verify] ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+      @connection.read_timeout = options[:read_timeout] || @connection.read_timeout
     end
 
     def request(req)


### PR DESCRIPTION
This adds the possibility to configure the read_timeout delay (in seconds) for API requests.